### PR TITLE
Rename `with` to `with_args`

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ end
 it "gets a page" do
   HTTPotion.get("http://example.com")
 
-  expect HTTPotion |> to_have_received :get |> with "http://example.com"
+  expect HTTPotion |> to_have_received :get |> with_args "http://example.com"
 end
 ```
 

--- a/lib/mocks/matchers.ex
+++ b/lib/mocks/matchers.ex
@@ -61,9 +61,9 @@ defmodule Pavlov.Mocks.Matchers do
   arguments passed in to the given method.
 
   ## Example
-      expect HTTPotion |> to_have_received :get |> with "http://example.com"
+      expect HTTPotion |> to_have_received :get |> with_args "http://example.com"
   """
-  def with(method, args) do
+  def with_args(method, args) do
     {method, args}
   end
 

--- a/lib/mocks/matchers/messages.ex
+++ b/lib/mocks/matchers/messages.ex
@@ -14,7 +14,7 @@ defmodule Pavlov.Mocks.Matchers.Messages do
     args = inspect args
 
     case matcher_name do
-      :have_received -> "Expected #{module} to have received #{method} with #{args}"
+      :have_received -> "Expected #{module} to have received #{method} with_args #{args}"
     end
   end
 

--- a/test/mocks_test.exs
+++ b/test/mocks_test.exs
@@ -98,7 +98,7 @@ defmodule PavlovMocksTest do
 
       Fixtures.Mockable.do_with_args("a string")
 
-      expect Fixtures.Mockable |> to_have_received :do_with_args |> with "a string"
+      expect Fixtures.Mockable |> to_have_received :do_with_args |> with_args "a string"
     end
 
     it "allows setting expectations matching method and several arguments" do
@@ -106,7 +106,7 @@ defmodule PavlovMocksTest do
 
       Fixtures.Mockable.do_with_several_args(1, 2)
 
-      expect Fixtures.Mockable |> to_have_received :do_with_several_args |> with [:_, 2]
+      expect Fixtures.Mockable |> to_have_received :do_with_several_args |> with_args [:_, 2]
     end
 
     it "allows mocking with arguments to return something" do
@@ -114,7 +114,7 @@ defmodule PavlovMocksTest do
 
       result = Fixtures.Mockable.do_with_args("a string")
 
-      expect Fixtures.Mockable |> to_have_received :do_with_args |> with "a string"
+      expect Fixtures.Mockable |> to_have_received :do_with_args |> with_args "a string"
       expect result |> to_eq :error
     end
 
@@ -122,7 +122,7 @@ defmodule PavlovMocksTest do
       message = message_for_matcher(:have_received, [Fixtures.Mockable, :do_with_args, [1]], :assertion)
 
       expect message
-        |> to_eq "Expected Elixir.Fixtures.Mockable to have received :do_with_args with [1]"
+        |> to_eq "Expected Elixir.Fixtures.Mockable to have received :do_with_args with_args [1]"
     end
   end
 


### PR DESCRIPTION
Elixir 1.2 causes a compile error:

```
cannot import Pavlov.Mocks.Matchers.with/2 because it conflicts with Elixir special forms
```

Lots of warnings are still printed, but this PR does not address that issue.

Closes #48
